### PR TITLE
Add support for baseURL for relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,54 @@ is processed as:
 ```adoc
 link:https://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html[`java.util.logging`]
 ```
+
+### Relative URLs
+
+It can be convenient to use relative URLs when referencing some Javadoc from the project itself, 
+when it is hosted at the same place as the userguide.
+
+For instance:
+
+```
+https://my.company.com/docs/v1.0.0/userguide.html
+https://my.company.com/docs/v1.0.0/apidocs/index.html
+```
+
+```properties
+com.company.my=apidocs/
+```
+
+But when using other Asciidoctor backends like pdf, those relative links will be broken.
+
+To solve this, the attribute `apidocs_baseurl` configures the base URL to use for relative Javadoc URLs:
+
+```xml
+<plugin>
+  <groupId>org.asciidoctor</groupId>
+  <artifactId>asciidoctor-maven-plugin</artifactId>
+  <configuration>
+    <attributes>
+      <apidocs_config>apidoc.properties</apidocs_config>
+    </attributes>
+  </configuration>
+  <executions>
+     <execution>
+        <id>backend-html</id>
+        <configuration>
+            <backend>html5</backend>
+            <!-- Keep relative links, as HTML userguide will be hosted alongside the Javadoc -->
+        </configuration>
+     </execution>
+     <execution>
+        <id>backend-pdf</id>
+        <configuration>
+            <backend>pdf</backend>
+            <attributes>
+              <!-- Transform relative links into absolute URLs -->
+              <apidocs_baseurl>https://my.company.com/</apidocs_baseurl>
+            </attributes>        
+        </configuration>
+     </execution>
+  </executions>
+</plugin>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,9 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <source>8</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/test/java/com/amadeus/asciidoc/apidoc/ApidocExtensionTest.java
+++ b/src/test/java/com/amadeus/asciidoc/apidoc/ApidocExtensionTest.java
@@ -29,21 +29,21 @@ public class ApidocExtensionTest {
 
   private static Asciidoctor asciidoctor;
 
-  private static Map<String, Object> options = new HashMap<>();
+  private Map<String, Object> options = new HashMap<>();
 
-  private static Attributes attributes = new Attributes();
+  private Attributes attributes = new Attributes();
 
   private StubLogHandler logHandler = new StubLogHandler();
 
   @BeforeAll
   public static void setUpOnce() {
     asciidoctor = Asciidoctor.Factory.create(); // Slow, do it only once.
-    attributes.setAttribute(ImplicitApidocMacro.ATTRIBUTE_APIDOCS_CONFIG, "src/test/resources/apidoc.properties");
-    options = OptionsBuilder.options().attributes(attributes).asMap();
   }
 
   @BeforeEach
   public void setUp() {
+    attributes.setAttribute(ImplicitApidocMacro.ATTRIBUTE_APIDOCS_CONFIG, "src/test/resources/apidoc.properties");
+    options = OptionsBuilder.options().attributes(attributes).asMap();
     asciidoctor.registerLogHandler(logHandler);
   }
 
@@ -114,6 +114,16 @@ public class ApidocExtensionTest {
   }
 
   @Test
+  public void relativeLinksWithBaseUrl() {
+    attributes.setAttribute(ImplicitApidocMacro.ATTRIBUTE_APIDOCS_BASE_URL, "https://my.company.com/");
+    Map<String, Object> options = OptionsBuilder.options().attributes(attributes).asMap();
+
+    String output = asciidoctor.convert("com.company.my.Class", options);
+
+    assertEquals(block("<a href=\"https://my.company.com/apidocs/com/company/my/Class.html\">Class</a>"), output);
+  }
+
+  @Test
   public void passthroughShouldSkipMacro() {
     String output = asciidoctor.convert("pass:[com.company.my.Class]", options);
 
@@ -173,7 +183,7 @@ public class ApidocExtensionTest {
   }
 
   @Test
-  public void unkownPackageBaseApidocShouldSkipAndWarn() {
+  public void unknownPackageBaseApidocShouldSkipAndWarn() {
     String output = asciidoctor.convert("com.unknown.Class", options);
 
     assertEquals(block("com.unknown.Class"), output);


### PR DESCRIPTION
Fixes #40 
Add a new attribute `:apidocs_baseuri:`
If set, it'll be used to prefix any relative URLs matched in apidocs.properties