### PR TITLE
feat(deps): Migration to Asciidoctorj v3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amadeus.asciidoc</groupId>
   <artifactId>asciidoctor-extension-apidoc</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>asciidoctor-extension-apidoc</name>
@@ -55,7 +55,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <asciidoctorj.version>2.5.10</asciidoctorj.version>
+    <asciidoctorj.version>3.0.0</asciidoctorj.version>
 
     <junit.jupiter.version>5.10.0</junit.jupiter.version>
     <junit.platform.version>1.10.0</junit.platform.version>

--- a/src/it/sample/pom.xml
+++ b/src/it/sample/pom.xml
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>2.0.0-RC.1</version>
+        <version>3.0.0</version>
         <configuration>
           <!-- Common configuration to all backends -->
           <enableVerbose>true</enableVerbose>
@@ -70,7 +70,7 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
-            <version>1.5.0-alpha.17</version>
+            <version>2.3.18</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/src/main/java/com/amadeus/asciidoc/apidoc/ImplicitApidocMacro.java
+++ b/src/main/java/com/amadeus/asciidoc/apidoc/ImplicitApidocMacro.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.Format;
 import org.asciidoctor.extension.FormatType;
 import org.asciidoctor.extension.InlineMacroProcessor;
@@ -60,7 +61,7 @@ public class ImplicitApidocMacro extends InlineMacroProcessor {
   private ApidocRegistry registry = null;
 
   @Override
-  public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+  public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
     LOG.log(Level.FINE, "Processing {0}", target);
     Map<String, Object> documentAttributes = parent.getDocument().getAttributes();
 

--- a/src/test/java/com/amadeus/asciidoc/apidoc/ApidocExtensionTest.java
+++ b/src/test/java/com/amadeus/asciidoc/apidoc/ApidocExtensionTest.java
@@ -29,9 +29,9 @@ public class ApidocExtensionTest {
 
   private static Asciidoctor asciidoctor;
 
-  private Map<String, Object> options = new HashMap<>();
+  private Options options;
 
-  private Attributes attributes = new Attributes();
+  private Attributes attributes = Attributes.builder().build();
 
   private StubLogHandler logHandler = new StubLogHandler();
 
@@ -43,7 +43,7 @@ public class ApidocExtensionTest {
   @BeforeEach
   public void setUp() {
     attributes.setAttribute(ImplicitApidocMacro.ATTRIBUTE_APIDOCS_CONFIG, "src/test/resources/apidoc.properties");
-    options = OptionsBuilder.options().attributes(attributes).asMap();
+    options = Options.builder().attributes(attributes).build();
     asciidoctor.registerLogHandler(logHandler);
   }
 
@@ -116,7 +116,7 @@ public class ApidocExtensionTest {
   @Test
   public void relativeLinksWithBaseUrl() {
     attributes.setAttribute(ImplicitApidocMacro.ATTRIBUTE_APIDOCS_BASE_URL, "https://my.company.com/");
-    Map<String, Object> options = OptionsBuilder.options().attributes(attributes).asMap();
+    Options options = Options.builder().attributes(attributes).build();
 
     String output = asciidoctor.convert("com.company.my.Class", options);
 
@@ -200,7 +200,7 @@ public class ApidocExtensionTest {
 
   @Test
   public void renderExampleWithoutConfig() {
-    Options options = new Options();
+    Options options = Options.builder().build();
     options.setToFile("target/sample.html");
     asciidoctor.convertFile(new File("src/it/sample/sample.adoc"), options);
 
@@ -210,7 +210,7 @@ public class ApidocExtensionTest {
 
   @Test
   public void renderExample() {
-    Options options = OptionsBuilder.options().attributes(attributes).get();
+    Options options = Options.builder().attributes(attributes).build();
     options.setToFile("target/sample.html");
     asciidoctor.convertFile(new File("src/it/sample/sample.adoc"), options);
 

--- a/src/test/java/com/amadeus/asciidoc/apidoc/ImplicitApidocMacroTest.java
+++ b/src/test/java/com/amadeus/asciidoc/apidoc/ImplicitApidocMacroTest.java
@@ -1,5 +1,8 @@
 package com.amadeus.asciidoc.apidoc;
 
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -25,14 +28,14 @@ public class ImplicitApidocMacroTest {
   static ImplicitApidocMacro macro;
 
   @Mock
-  private ContentNode parent;
+  private StructuralNode parent;
 
   @Mock
   private Document document;
 
-  private final Attributes attributes = new Attributes();
+  private final Attributes attributes = Attributes.builder().build();
 
-  private final Map<String, Object> options = OptionsBuilder.options().asMap();
+  private final Map<String, Object> options = Options.builder().build().map();
 
   @BeforeEach
   public void setUp() {
@@ -46,7 +49,7 @@ public class ImplicitApidocMacroTest {
   @Disabled("#log requires a JRuby runtime")
   @Test
   public void unknownPackageShouldSkipProcessing() {
-    String output = (String)macro.process(parent, "com.unknown.Class", options);
+    String output = macro.process(parent, "com.unknown.Class", options).convert();
 
     assertEquals("com.unknown.Class", output);
   }
@@ -54,7 +57,7 @@ public class ImplicitApidocMacroTest {
   @Disabled("JRuby bugs when calling Inline#convert, see ImplicitApidocMacroAscidocTest instead")
   @Test
   public void relativeLinks() {
-    String output = (String)macro.process(parent, "com.company.my.Class", options);
+    String output = macro.process(parent, "com.company.my.Class", options).convert();
 
     assertEquals("<a href=\"apidocs/com/company/my/Class.html\">Class</a>", output);
   }


### PR DESCRIPTION
This version has introduced some breaking changes amongst which a removal of deprecated methods, which are breaking the extension and its tests.
Asciidoctor-maven-plugin has been updated to 3.0.0 also in the IT test.

Looking at the non-backwards-compatible nature of the upgrade, setting base version to 2.0-SNAPSHOT.